### PR TITLE
Fix a memory leak introduced with the addition of row separators.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,18 @@ OutlineView(data, children: \.children, selection: $selection) { item in
 .rowSeparator(.visible)
 ```
 
-By default, macOS will attepmt to draw separators with appropriate insets based on the style of the `OutlineView` and the contents of the cell. To customize the separator insets, you can use the initilaizer which takes `separatorInsets` as an argument. `separatorInsets` is a closure that specifies the edge insets of a separator for the row displaying the data element.
+By default, macOS will attempt to draw separators with appropriate insets based on the style of the `OutlineView` and the contents of the cell. To customize the separator insets, you can use the initializer which takes `separatorInsets` as an argument. `separatorInsets` is a closure that returns the edge insets of a separator for the row displaying the provided data element.
+
+>Note: This initializer is only available on macOS 11.0 and higher.
 
 ```swift
+let separatorInset = NSEdgeInsets(top: 0, left: 24, bottom: 0, right: 0)
+
 OutlineView(
   data, 
   children: \.children, 
   selection: $selection
-  separatorInsets: { item in NSEdgeInsets(top: 0, left: 24, bottom: 0, right: 0) }) { item in
+  separatorInsets: { item in separatorInset }) { item in
   NSTextField(string: item.description)
 }
 ```

--- a/Sources/OutlineView/AdjustableSeparatorRowView.swift
+++ b/Sources/OutlineView/AdjustableSeparatorRowView.swift
@@ -2,7 +2,8 @@ import AppKit
 import ObjectiveC
 
 /// An NSTableRowView with an adjustable separator line.
-class AdjustableSeparatorRowView: NSTableRowView {
+@available(macOS 11.0, *)
+final class AdjustableSeparatorRowView: NSTableRowView {
     var separatorInsets: NSEdgeInsets?
 
     public override init(frame frameRect: NSRect) {
@@ -19,6 +20,11 @@ class AdjustableSeparatorRowView: NSTableRowView {
     /// Computes the frame of the `_separatorView`.
     @objc
     func separatorRect() -> CGRect {
+        // Make sure we only override the behavior for this class.
+        guard type(of: self) == AdjustableSeparatorRowView.self else {
+            return Self.originalSeparatorRect?(self) ?? .zero
+        }
+
         // Only override the default behavior if the
         // separator insets are not available.
         guard let separatorInsets = separatorInsets else {
@@ -44,8 +50,8 @@ class AdjustableSeparatorRowView: NSTableRowView {
             height: separatorRect.height - separatorInsets.top - separatorInsets.bottom)
     }
 
-    /// Stores the original implementation of `_separatorRect` if sucessfully swizzled.
-    static var originalSeparatorRect: ((AdjustableSeparatorRowView) -> CGRect)?
+    /// Stores the original implementation of `_separatorRect` if successfully swizzled.
+    static var originalSeparatorRect: ((NSTableRowView) -> CGRect)?
 
     /// Swizzle the private `_separatorRect` defined on NSTableRowView.
     /// Should be executed early in the life-cycle of `AdjustableSeparatorRowView`.
@@ -61,7 +67,7 @@ class AdjustableSeparatorRowView: NSTableRowView {
                 #selector(separatorRect))
         else { return }
 
-        // Replace the original implmentation with our implementation.
+        // Replace the original implementation with our implementation.
         let originalImplementation = method_setImplementation(
             originalMethod,
             method_getImplementation(newMethod))

--- a/Sources/OutlineView/OutlineView.swift
+++ b/Sources/OutlineView/OutlineView.swift
@@ -103,6 +103,7 @@ where Data.Element: Identifiable {
     ///     element in `data`. An `NSTableCellView` subclass is preferred.
     ///     The `NSView` should return the correct `fittingSize`
     ///     as it is used to determine the height of the cell.
+    @available(macOS 11.0, *)
     public init(
         _ data: Data,
         children: KeyPath<Data.Element, Data?>,

--- a/Sources/OutlineView/OutlineView.swift
+++ b/Sources/OutlineView/OutlineView.swift
@@ -19,9 +19,9 @@ where Data.Element: Identifiable {
     @available(macOS 11.0, *)
     var style: NSOutlineView.Style {
         get {
-            _styleStorage.map {
-                unsafeBitCast($0, to: NSOutlineView.Style.self)
-            } ?? .automatic
+            _styleStorage
+                .flatMap { $0 as? NSOutlineView.Style }
+                ?? .automatic
         }
         set { _styleStorage = newValue }
     }


### PR DESCRIPTION
There seems to be a memory leak on macOS 11 where row views returned from `rowViewForItem` are never freed. The row views are stored in a private `NSMutableSet` on `NSTableRowData` (Path: `tableView._rowData._rowViewPurgatory`) once they are available for reuse. An `AdjustableSeparatorRowView` is never reused, but still remains a member of the set. So, to patch the leak, we are manually removing it from the set.