### PR TITLE
Reusable NSTableCellViews

### DIFF
--- a/Sources/OutlineView/OutlineViewController.swift
+++ b/Sources/OutlineView/OutlineViewController.swift
@@ -1,13 +1,13 @@
 import Cocoa
 
 @available(macOS 10.15, *)
-public class OutlineViewController<Data: Sequence, Drop: DropReceiver>: NSViewController
+public class OutlineViewController<Data: Sequence, Drop: DropReceiver, CellType: NSView>: NSViewController
 where Drop.DataElement == Data.Element {
     let outlineView = NSOutlineView()
     let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 400, height: 400))
     
     let dataSource: OutlineViewDataSource<Data, Drop>
-    let delegate: OutlineViewDelegate<Data>
+    let delegate: OutlineViewDelegate<Data, CellType>
     let updater = OutlineViewUpdater<Data>()
 
     let childrenSource: ChildSource<Data>
@@ -15,7 +15,7 @@ where Drop.DataElement == Data.Element {
     init(
         data: Data,
         childrenSource: ChildSource<Data>,
-        content: @escaping (Data.Element) -> NSView,
+        content: CellBuilder<Data, CellType>,
         selectionChanged: @escaping (Data.Element?) -> Void,
         separatorInsets: ((Data.Element) -> NSEdgeInsets)?
     ) {

--- a/Sources/OutlineView/OutlineViewDelegate.swift
+++ b/Sources/OutlineView/OutlineViewDelegate.swift
@@ -1,9 +1,9 @@
 import Cocoa
 
 @available(macOS 10.15, *)
-class OutlineViewDelegate<Data: Sequence>: NSObject, NSOutlineViewDelegate
+class OutlineViewDelegate<Data: Sequence, CellType: NSView>: NSObject, NSOutlineViewDelegate
 where Data.Element: Identifiable {
-    let content: (Data.Element) -> NSView
+    let content: CellBuilder<Data, CellType>
     let selectionChanged: (Data.Element?) -> Void
     let separatorInsets: ((Data.Element) -> NSEdgeInsets)?
     var selectedItem: OutlineViewItem<Data>?
@@ -13,7 +13,7 @@ where Data.Element: Identifiable {
     }
 
     init(
-        content: @escaping (Data.Element) -> NSView,
+        content: CellBuilder<Data, CellType>,
         selectionChanged: @escaping (Data.Element?) -> Void,
         separatorInsets: ((Data.Element) -> NSEdgeInsets)?
     ) {
@@ -27,7 +27,7 @@ where Data.Element: Identifiable {
         viewFor tableColumn: NSTableColumn?,
         item: Any
     ) -> NSView? {
-        content(typedItem(item).value)
+        content.cell(in: outlineView, item: typedItem(item).value)
     }
 
     func outlineView(
@@ -94,7 +94,7 @@ where Data.Element: Identifiable {
         // separately. It does not seem efficient to create a new cell to find
         // out the width of a cell. In practice I have not experienced any issues
         // with a moderate number of cells.
-        let view = content(typedItem(item).value)
+        let view = content.cell(in: outlineView, item: typedItem(item).value)
         view.widthAnchor.constraint(equalToConstant: width).isActive = true
         return view.fittingSize.height
     }


### PR DESCRIPTION
As I mentioned in https://github.com/Sameesunkaria/OutlineView/issues/12 `NSOutlineViewDelegate` recommends reusing cell views. I simplified my original code to use reusable cells into one that allows implementations of `OutlineView` to use either the existing single-use views (`content: (Data.Element) -> NSView`) or a closure that handles view reuse.

The new option for `content` parameter in `OutlineView` initializers looks something like this:

``` swift
OutlineView(
    data,
    selection: $selection,
    children: \.children,
    separatorInsets: separatorInsets
) { (rowView: FileItemView?, fileItem: FileItem) in
    if let rowView {
        // A reused FileItemView was provided.
        rowView.configure(with: fileItem)
        return rowView
    } else {
        // No FileItemView was available for reuse, so create and configure a new one.
        let newRowView = FileItemView()
        newRowView.configure(with: fileItem)
        return newRowView
    }
}
```

I provided new initializers for `OutlineView`, which brings the number of different initializers up to 16 (oof!), but by doing so I was able to make the update without breaking earlier versions. I haven't updated the example app in this PR or updated the `README.md` file, though I'll do those if you are interested in merging.